### PR TITLE
Fix compilation warnings for Elixir 1.4. Remove trailing whitespace.

### DIFF
--- a/lib/ex_ami/client.ex
+++ b/lib/ex_ami/client.ex
@@ -5,15 +5,15 @@ defmodule ExAmi.Client do
   alias ExAmi.ServerConfig
 
   defmodule ClientState do
-    defstruct name: "", server_info: "", listeners: [], actions: HashDict.new, 
-              connection: nil, counter: 0, logging: false, worker_name: nil, 
+    defstruct name: "", server_info: "", listeners: [], actions: Map.new,
+              connection: nil, counter: 0, logging: false, worker_name: nil,
               reader: nil
-  end 
+  end
 
   ###################
   # API
 
-  def start_link(server_name, worker_name, server_info), 
+  def start_link(server_name, worker_name, server_info),
     do: _start_link([server_name, worker_name, server_info])
 
   def start_link(server_name) do
@@ -30,23 +30,23 @@ defmodule ExAmi.Client do
     ExAmi.Supervisor.start_child(server_name)
   end
 
-  def process_salutation(client, salutation), 
+  def process_salutation(client, salutation),
     do: :gen_fsm.send_event(client, {:salutation, salutation})
 
-  def process_response(client, {:response, response}), 
+  def process_response(client, {:response, response}),
     do: :gen_fsm.send_event(client, {:response, response})
-    
-  def process_event(client, {:event, event}), 
+
+  def process_event(client, {:event, event}),
     do: :gen_fsm.send_event(client, {:event, event})
 
-  def register_listener(pid, listener_descriptor) when is_pid(pid), 
+  def register_listener(pid, listener_descriptor) when is_pid(pid),
     do: _register_listener(pid, listener_descriptor)
-  def register_listener(client, listener_descriptor), 
+  def register_listener(client, listener_descriptor),
     do: _register_listener(get_worker_name(client), listener_descriptor)
-  defp _register_listener(client, listener_descriptor), 
+  defp _register_listener(client, listener_descriptor),
     do: :gen_fsm.send_all_state_event(client, {:register, listener_descriptor})
 
-  def get_worker_name(asterisk_server_name) when is_atom(asterisk_server_name) do 
+  def get_worker_name(asterisk_server_name) when is_atom(asterisk_server_name) do
     Atom.to_string(asterisk_server_name)
     |> get_worker_name
   end
@@ -58,29 +58,29 @@ defmodule ExAmi.Client do
     |> String.to_atom
   end
 
-  def send_action(pid, action, callback) when is_pid(pid), 
+  def send_action(pid, action, callback) when is_pid(pid),
     do: _send_action(pid, action, callback)
-  def send_action(client, action, callback), 
+  def send_action(client, action, callback),
     do: _send_action(get_worker_name(client), action, callback)
-  defp _send_action(client, action, callback), 
-    do: :gen_fsm.send_event(client, {:action, action, callback}) 
+  defp _send_action(client, action, callback),
+    do: :gen_fsm.send_event(client, {:action, action, callback})
 
   def stop(pid), do: :gen_fsm.send_all_state_event(pid, :stop)
-  
+
   ###################
   # Callbacks
 
   def init([server_name, worker_name, server_info]) do
     {conn_module, conn_options} = ServerConfig.get server_info, :connection
-    {:ok, conn} = :erlang.apply(conn_module, :open, [conn_options]) 
+    {:ok, conn} = :erlang.apply(conn_module, :open, [conn_options])
     reader = ExAmi.Reader.start_link(worker_name, conn)
-    {:ok, :wait_saluation, 
+    {:ok, :wait_saluation,
       %ClientState{
-        name: server_name, server_info: server_info, connection: conn, 
+        name: server_name, server_info: server_info, connection: conn,
         worker_name: worker_name, reader: reader
       }}
   end
-  
+
   ###################
   # States
 
@@ -99,33 +99,33 @@ defmodule ExAmi.Client do
       false ->
         :error_logger.error_msg('Cant login: ~p', [response])
         :erlang.error(:cantlogin)
-      true -> 
+      true ->
         next_state state, :receiving
     end
   end
-  
+
   def receiving({:response, response}, %ClientState{actions: actions} = state) do
     if state.logging, do: Logger.debug(ExAmi.Message.format_log(response))
 
     # Find the correct action information for this response
     {:ok, action_id} = ExAmi.Message.get(response, "ActionID")
-    {action, :none, events, callback} = Dict.fetch!(actions, action_id)
+    {action, :none, events, callback} = Map.fetch!(actions, action_id)
     # See if we should dispatch this right away or wait for the events needed
     # to complete the response.
     new_actions = cond do
-      ExAmi.Message.is_response_error(response) -> 
+      ExAmi.Message.is_response_error(response) ->
         if callback, do: callback.(response, events)
         actions
 
-      ExAmi.Message.is_response_complete(response) -> 
+      ExAmi.Message.is_response_complete(response) ->
         # Complete response. Dispatch and remove the action from the queue.
         if callback, do: callback.(response, events)
-        Dict.delete(actions, action_id)
-        
+        Map.delete(actions, action_id)
+
       true ->
         # Save the response so we can receive the associated events to
         # dispatch later.
-        Dict.put(actions, action_id, {action, response, [], callback})
+        Map.put(actions, action_id, {action, response, [], callback})
     end
     struct(state, actions: new_actions)
     |> next_state(:receiving)
@@ -139,7 +139,7 @@ defmodule ExAmi.Client do
         next_state state, :receiving
       {:ok, action_id} ->
         # this one belongs to a response
-        case Dict.get(actions, action_id) do
+        case Map.get(actions, action_id) do
           nil ->
             # ignore: not ours, or stale.
             next_state state, :receiving
@@ -147,10 +147,10 @@ defmodule ExAmi.Client do
             new_events = [event|events]
             new_actions = case ExAmi.Message.is_event_last_for_response(event) do
               false ->
-                Dict.put(actions, action_id, {action, response, new_events, callback})
+                Map.put(actions, action_id, {action, response, new_events, callback})
               true ->
                 if callback, do: callback.(response, Enum.reverse(new_events))
-                Dict.delete state.actions, action_id
+                Map.delete state.actions, action_id
             end
             struct(state, actions: new_actions)
             |> next_state(:receiving)
@@ -160,13 +160,13 @@ defmodule ExAmi.Client do
 
   def receiving({:action, action, callback}, state) do
     {:ok, action_id} = ExAmi.Message.get(action, "ActionID")
-    new_state = struct(state, 
-      actions: Dict.put(state.actions, action_id, {action, :none, [], callback}))
+    new_state = struct(state,
+      actions: Map.put(state.actions, action_id, {action, :none, [], callback}))
     :ok = state.connection.send.(action)
     next_state new_state, :receiving
   end
 
-  def handle_event({:register, listener_descriptor}, state_name, 
+  def handle_event({:register, listener_descriptor}, state_name,
       %ClientState{listeners: listeners} = client_state) do
     struct(client_state, listeners: [listener_descriptor | listeners])
     |> next_state(state_name)
@@ -176,23 +176,23 @@ defmodule ExAmi.Client do
     send reader, :stop
     # Give reader a chance to timeout, receive the :stop, and shutdown
     :timer.sleep(100)
-    ExAmi.Supervisor.stop_child(self)
+    ExAmi.Supervisor.stop_child(self())
     {:stop, :normal, state}
   end
 
-  def handle_event(_event, state_name, state), 
+  def handle_event(_event, state_name, state),
     do: next_state(state, state_name)
 
   def handle_sync_event(:next_worker, _from, state_name, %{name: name} = state) do
     next = state.counter + 1
-    new_worker_name = String.to_atom "#{get_worker_name(name)}_#{next}" 
+    new_worker_name = String.to_atom "#{get_worker_name(name)}_#{next}"
     struct(state, counter: next)
     |> reply([name, new_worker_name, state.server_info], state_name)
   end
-  def handle_sync_event(_event, _from, state_name, state), 
+  def handle_sync_event(_event, _from, state_name, state),
     do: reply(state, :ok, state_name)
-    
-  def handle_info(_info, state_name, state), 
+
+  def handle_info(_info, state_name, state),
     do: next_state(state, state_name)
 
   ###################
@@ -202,16 +202,16 @@ defmodule ExAmi.Client do
   defp validate_salutation("Asterisk Call Manager/1.0\r\n"), do: :ok
   defp validate_salutation("Asterisk Call Manager/1.2\r\n"), do: :ok
   defp validate_salutation("Asterisk Call Manager/1.3\r\n"), do: :ok
-  defp validate_salutation(invalid_id) do 
+  defp validate_salutation(invalid_id) do
     Logger.error "Invalid Salutation #{inspect invalid_id}"
     :unknown_salutation
   end
 
   defp dispatch_event(server_name, event, listeners) do
-    Enum.each(listeners,  
+    Enum.each(listeners,
       fn({function, predicate}) ->
         # spawn(fn ->
-          case :erlang.apply(predicate, [event]) do 
+          case :erlang.apply(predicate, [event]) do
             true -> function.(server_name, event)
             _ -> :ok
           end

--- a/lib/ex_ami/client/originate.ex
+++ b/lib/ex_ami/client/originate.ex
@@ -1,7 +1,7 @@
 defmodule ExAmi.Client.Originate do
   require Logger
   alias ExAmi.Client
- 
+
   def dial(sever_name, channel, other, variables \\ [], callback \\ nil, opts \\ [])
   def dial(server_name, channel, {context, extension, priority}, variables, callback, opts) do
     action_params = %{
@@ -12,27 +12,27 @@ defmodule ExAmi.Client.Originate do
 
     {:ok, client_pid} = ExAmi.Client.start_child(server_name)
 
-    Client.register_listener(client_pid, { 
+    Client.register_listener(client_pid, {
       &(event_listener(client_pid, &1, &2, action_params)),
-      &(Dict.get(&1.attributes, "Event") in ~w(FullyBooted Hangup))
+      &(Map.get(&1.attributes, "Event") in ~w(FullyBooted Hangup))
     })
     {:ok, client_pid}
   end
   def dial(server_name, channel, extension, variables, callback, opts), do:
     dial(server_name, channel, {"from-internal", extension, "1"}, variables, callback, opts)
-        
+
   #####################
   # Listener
- 
-  def event_listener(client_pid, _server_name, 
+
+  def event_listener(client_pid, _server_name,
       %{attributes: attributes}, action_params) do
-    
-    case Dict.get(attributes, "Event") do
-      "FullyBooted" -> 
+
+    case Map.get(attributes, "Event") do
+      "FullyBooted" ->
         send_action(client_pid, action_params)
-      "Hangup" -> 
+      "Hangup" ->
         %{channel: orig_channel} = action_params
-        event_channel = Dict.get(attributes, "Channel")
+        event_channel = Map.get(attributes, "Channel")
         if String.match? event_channel, ~r/#{orig_channel}/ do
           Client.stop client_pid
         end
@@ -40,7 +40,7 @@ defmodule ExAmi.Client.Originate do
   end
 
   def send_action(client_pid, %{
-      channel: channel, context: context, extension: extension, 
+      channel: channel, context: context, extension: extension,
       priority: priority, variables: variables, callback: callback, other: opts }) do
 
     action = ExAmi.Message.new_action(

--- a/lib/ex_ami/connection.ex
+++ b/lib/ex_ami/connection.ex
@@ -4,15 +4,15 @@ defmodule ExAmi.Connection do
               send: &__MODULE__.send_not_implemented/1,
               close: &__MODULE__.close_not_implemented/1
 
-    def new(), do: %__MODULE__{} 
-    def new(opts), do: struct(new, opts)
+    def new(), do: %__MODULE__{}
+    def new(opts), do: struct(new(), opts)
 
     def read_line_not_implemented(_), do: :erlang.error('Not implemented')
     def send_not_implemented(_), do: :erlang.error('Not implemented')
     def close_not_implemented(_), do: :erlang.error('Not implemented')
   end
 
-  def behaviour_info(:callbacks), 
+  def behaviour_info(:callbacks),
     do: [open: 1, read_line: 2, send: 2, close: 1]
   def behaviour_info(_), do: :undefined
 
@@ -29,5 +29,5 @@ defmodule ExAmi.Connection do
       other -> other
     end
   end
-  
+
 end

--- a/lib/ex_ami/message.ex
+++ b/lib/ex_ami/message.ex
@@ -2,18 +2,17 @@ defmodule ExAmi.Message do
   require Logger
 
   @eol  "\r\n"
-  @eom  "\r\n\r\n"
 
   defmodule Message do
-    defstruct attributes: HashDict.new, variables: HashDict.new
+    defstruct attributes: Map.new, variables: Map.new
     def new, do: %__MODULE__{}
-    def new(attributes, variables), 
+    def new(attributes, variables),
       do: %__MODULE__{attributes: attributes, variables: variables}
-    def new(opts), do: struct(new, opts)
+    def new(opts), do: struct(new(), opts)
   end
 
   def new_message, do: Message.new
-  def new_message(attributes, variables), 
+  def new_message(attributes, variables),
     do: Message.new(attributes, variables)
 
   def new_action(name) do
@@ -22,7 +21,7 @@ defmodule ExAmi.Message do
     |> Enum.map(&(Integer.to_string(&1)))
     |> Enum.reduce("", &(&2 <> &1))
 
-    set_all(new_message, [{"Action", name}, {"ActionID", action_id}])
+    set_all(new_message(), [{"Action", name}, {"ActionID", action_id}])
   end
 
   def new_action(name, attributes) do
@@ -37,25 +36,25 @@ defmodule ExAmi.Message do
   end
 
   def get(%Message{attributes: attributes}, key) do
-    case Dict.fetch(attributes, key) do
+    case Map.fetch(attributes, key) do
       {:ok, value} -> {:ok, value}
       _ -> :notfound
     end
   end
 
   def get_variable(%Message{variables: variables}, key) do
-    case Dict.fetch variables, key do
+    case Map.fetch variables, key do
       {:ok, value} -> {:ok, value}
       _ -> :notfound
     end
   end
-  
+
   def set(key, value) do
-    new_message |> set(key, value)
+    new_message() |> set(key, value)
   end
 
   def set(%Message{} = message, key, value) do
-    Dict.put(message.attributes, key, value)   
+    Map.put(message.attributes, key, value)
     |> new_message(message.variables)
   end
 
@@ -63,39 +62,39 @@ defmodule ExAmi.Message do
     Enum.reduce attributes, message, fn({key, value}, acc) -> set(acc, key, value) end
   end
 
-  def set_variable(%Message{variables: variables, attributes: attributes}, key, value), 
-    do: new_message(attributes, Dict.put(variables, key, value))
+  def set_variable(%Message{variables: variables, attributes: attributes}, key, value),
+    do: new_message(attributes, Map.put(variables, key, value))
 
   def set_all_variables(%Message{} = message, variables) do
     Enum.reduce(variables, message, fn({key,value}, acc) -> set_variable(acc, key, value) end)
   end
 
   def marshall(%Message{attributes: attributes, variables: variables}) do
-    Enum.reduce(Dict.to_list(attributes), "", fn({k,v}, acc) -> marshall(acc, k, v) end) <>
-    Enum.reduce(Dict.to_list(variables), "", fn({k,v}, acc) -> marshall_variable(acc, k, v) end) <>
+    Enum.reduce(Map.to_list(attributes), "", fn({k,v}, acc) -> marshall(acc, k, v) end) <>
+    Enum.reduce(Map.to_list(variables), "", fn({k,v}, acc) -> marshall_variable(acc, k, v) end) <>
     @eol
   end
   def marshall(key, value), do: key <> ": " <> value <> @eol
-  def marshall(acc, key, value), do: acc <> marshall(key, value)    
+  def marshall(acc, key, value), do: acc <> marshall(key, value)
 
   def marshall_variable(key, value), do: marshall("Variable", key <> "=" <> value)
   def marshall_variable(acc, key, value), do: acc <> marshall("Variable", key <> "=" <> value)
- 
+
   def explode_lines(text), do: String.split(text, "\r\n", trim: true)
 
   def format_log(%{attributes: attributes}) do
-    cond do 
-      value = Dict.get(attributes, "Event") -> 
+    cond do
+      value = Map.get(attributes, "Event") ->
         format_log("Event", value, attributes)
-      value  = Dict.get(attributes, "Response") -> 
+      value  = Map.get(attributes, "Response") ->
         format_log("Response", value, attributes)
       true -> {:error, :notfound}
     end
   end
   def format_log(key, value, attributes) do
-    Dict.delete(attributes, key)
-    |> Dict.to_list
-    |> Enum.reduce(key <> ": \"" <> value <> "\"", fn({k,v}, acc) -> 
+    Map.delete(attributes, key)
+    |> Map.to_list
+    |> Enum.reduce(key <> ": \"" <> value <> "\"", fn({k,v}, acc) ->
       acc <> ", " <> k <> ": \"" <> v <> "\""
     end)
   end
@@ -103,17 +102,17 @@ defmodule ExAmi.Message do
 
 
   def unmarshall(text) do
-    Enum.reduce explode_lines(text), new_message, fn(line, acc) -> 
+    Enum.reduce explode_lines(text), new_message(), fn(line, acc) ->
       String.split(line, ":", trim: true, parts: 2)
       |> Enum.map(&(String.strip(&1)))
-      |> _unmarshall(acc)     
+      |> _unmarshall(acc)
     end
   end
-  defp _unmarshall([key,value], %Message{} = message), 
+  defp _unmarshall([key,value], %Message{} = message),
     do: set(message, key, value)
   defp _unmarshall([], %Message{} = message), do: message
   defp _unmarshall(["ReportBlock"], %Message{} = message), do: message
-  defp _unmarshall(other, %Message{} = message) do 
+  defp _unmarshall(other, %Message{} = message) do
     Logger.error("_unmarshall invalid input #{inspect other}")
     message
   end
@@ -152,5 +151,5 @@ defmodule ExAmi.Message do
       _ -> false
     end
   end
-  
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,12 +5,12 @@ defmodule ExAmi.Mixfile do
     [app: :ex_ami,
      version: "0.1.0",
      elixir: "~> 1.3",
-     package: package,
+     package: package(),
      name: "ExAmi",
      description: """
      An Elixir Asterisk AMI Client Library.
      """,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/test/message_test.exs
+++ b/test/message_test.exs
@@ -5,14 +5,14 @@ defmodule ExAmi.MessageTest do
   describe "setters" do
     test "sets all" do
       expected = %Message.Message{attributes:
-        Enum.into([{"one", "two"}, {"three", "four"}], HashDict.new)}
+        Enum.into([{"one", "two"}, {"three", "four"}], Map.new)}
       assert Message.new_message
       |> Message.set_all([{"one", "two"}, {"three", "four"}]) == expected
     end
 
     test "sets all variables" do
       expected = %Message.Message{variables:
-        Enum.into([{"one", "two"}, {"three", "four"}], HashDict.new)}
+        Enum.into([{"one", "two"}, {"three", "four"}], Map.new)}
       assert Message.new_message
       |> Message.set_all_variables([{"one", "two"}, {"three", "four"}]) == expected
     end
@@ -36,7 +36,7 @@ defmodule ExAmi.MessageTest do
     end
 
     test "handles simple Message" do
-      message = %Message.Message{attributes: Enum.into([{"one", "two"}], HashDict.new)}
+      message = %Message.Message{attributes: Enum.into([{"one", "two"}], Map.new)}
       assert Message.marshall(message) == "one: two\r\n\r\n"
     end
   end
@@ -50,12 +50,12 @@ defmodule ExAmi.MessageTest do
 
   describe "unmarshall" do
     test "handles an attribute" do
-      expected = %Message.Message{attributes: Enum.into([{"var", "name"}], HashDict.new)}
+      expected = %Message.Message{attributes: Enum.into([{"var", "name"}], Map.new)}
       assert Message.unmarshall("var: name\r\n") == expected
     end
     test "handles 2 attributes" do
       expected = %Message.Message{attributes: Enum.into(
-        [{"var", "name"}, {"var2", "name2"}], HashDict.new)}
+        [{"var", "name"}, {"var2", "name2"}], Map.new)}
       assert Message.unmarshall("var: name\r\nvar2: name2\r\n") == expected
     end
     test "handles a success response" do


### PR DESCRIPTION
Just add parentheses for several functions and replace HashDict with Map.