### PR TITLE
Support for Asterisk 18 and add .formatter.exs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,12 +10,13 @@ use Mix.Config
 
 # Sample configuration:
 #
-    config :logger, 
-      level: :debug
+config :logger,
+  level: :debug
+
 #
-    config :logger, :console,
-      format: "$date $time [$level] $metadata$message\n",
-      metadata: [:user_id]
+config :logger, :console,
+  format: "$date $time [$level] $metadata$message\n",
+  metadata: [:user_id]
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
@@ -25,5 +26,4 @@ use Mix.Config
 #
 #     import_config "#{Mix.env}.exs"
 
-
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,12 +1,16 @@
-
 use Mix.Config
 
-config :ex_ami, 
+config :ex_ami,
   servers: [
-    {:asterisk, [
-      {:connection, {ExAmi.TcpConnection, [
-        {:host, "127.0.0.1"}, {:port, 5038}
-      ]}},
-      {:username, "username"},
-      {:secret, "secret"}
-    ]} ]
+    {:asterisk,
+     [
+       {:connection,
+        {ExAmi.TcpConnection,
+         [
+           {:host, "127.0.0.1"},
+           {:port, 5038}
+         ]}},
+       {:username, "username"},
+       {:secret, "secret"}
+     ]}
+  ]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,3 +1,1 @@
-
 use Mix.Config
-

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,3 @@
-
 use Mix.Config
 
 config :ex_ami, servers: []

--- a/lib/ex_ami.ex
+++ b/lib/ex_ami.ex
@@ -3,13 +3,10 @@ defmodule ExAmi do
 
   def start(_type, _args) do
     {:ok, pid} = ExAmi.Supervisor.start_link([])
-    # |> IO.inspect(label: "ExAmi.start return")
 
     for {name, info} <- Application.get_env(:ex_ami, :servers, []) |> deep_parse() do
       worker_name = ExAmi.Client.get_worker_name(name)
-      # |> IO.inspect(label: "worker_name")
       ExAmi.Supervisor.start_child(name, worker_name, info)
-      # |> IO.inspect(label: "ExAmi.start start_child return")
     end
 
     {:ok, pid}

--- a/lib/ex_ami/client.ex
+++ b/lib/ex_ami/client.ex
@@ -168,7 +168,7 @@ defmodule ExAmi.Client do
 
         next_state(
           %ClientState{data | connection: conn, reader: reader, online: true},
-          :wait_saluation
+          :wait_salutation
         )
 
       _error ->
@@ -181,7 +181,7 @@ defmodule ExAmi.Client do
     handle_event(event_type, event_content, data)
   end
 
-  def wait_saluation(:cast, {:salutation, salutation}, state) do
+  def wait_salutation(:cast, {:salutation, salutation}, state) do
     :ok = validate_salutation(salutation)
     username = ServerConfig.get(state.server_info, :username)
     secret = ServerConfig.get(state.server_info, :secret)
@@ -192,7 +192,7 @@ defmodule ExAmi.Client do
     next_state(state, :wait_login_response)
   end
 
-  def wait_saluation(event_type, event_content, data) do
+  def wait_salutation(event_type, event_content, data) do
     handle_event(event_type, event_content, data)
   end
 
@@ -362,32 +362,32 @@ defmodule ExAmi.Client do
   defp connecting_timer(cnt) when cnt < 20, do: 30_000
   defp connecting_timer(_), do: 60_000
 
-  defp validate_salutation("Asterisk Call Manager/7.0." <> patch = saluation) do
-    check_version(patch, saluation)
+  defp validate_salutation("Asterisk Call Manager/7.0." <> patch = salutation) do
+    check_version(patch, salutation)
   end
 
-  defp validate_salutation("Asterisk Call Manager/2.10." <> patch = saluation) do
-    check_version(patch, saluation)
+  defp validate_salutation("Asterisk Call Manager/2.10." <> patch = salutation) do
+    check_version(patch, salutation)
   end
 
-  defp validate_salutation("Asterisk Call Manager/1." <> minor = saluation) do
-    check_version(minor, saluation)
+  defp validate_salutation("Asterisk Call Manager/1." <> minor = salutation) do
+    check_version(minor, salutation)
   end
 
   defp validate_salutation(invalid_id) do
-    saluation_error(invalid_id)
+    salutation_error(invalid_id)
   end
 
-  defp saluation_error(invalid_id) do
+  defp salutation_error(invalid_id) do
     Logger.error("Invalid Salutation #{inspect(invalid_id)}")
     :unknown_salutation
   end
 
-  defp check_version(number, saluation) do
+  defp check_version(number, salutation) do
     if Regex.match?(~r/\d+\r\n/, number) do
       :ok
     else
-      saluation_error(saluation)
+      salutation_error(salutation)
     end
   end
 

--- a/lib/ex_ami/client.ex
+++ b/lib/ex_ami/client.ex
@@ -23,7 +23,8 @@ defmodule ExAmi.Client do
   # API
 
   def child_spec([_, worker_name | _] = args) do
-    IO.inspect args, label: "ExAmi.child_spec 1"
+    IO.inspect(args, label: "ExAmi.child_spec 1")
+
     %{
       id: worker_name,
       start: {__MODULE__, :start_link, args},
@@ -33,8 +34,10 @@ defmodule ExAmi.Client do
   end
 
   def child_spec([server_name] = args) do
-    IO.inspect args, label: "ExAmi.child_spec 2"
-    args = [_, worker_name | _]=
+    IO.inspect(args, label: "ExAmi.child_spec 2")
+
+    args =
+      [_, worker_name | _] =
       server_name
       |> get_worker_name()
       |> GenStateMachine.call(:next_worker)
@@ -56,7 +59,8 @@ defmodule ExAmi.Client do
   end
 
   def start_link(server_name) do
-    IO.inspect server_name, label: "ExAmi.Client start_link/1"
+    IO.inspect(server_name, label: "ExAmi.Client start_link/1")
+
     server_name
     |> get_worker_name
     |> GenStateMachine.call(:next_worker)
@@ -65,6 +69,7 @@ defmodule ExAmi.Client do
 
   defp do_start_link([_, worker_name | _] = args) do
     IO.inspect(args, label: "ExAmi.Client.do_start_link")
+
     GenStateMachine.start_link(__MODULE__, args, name: worker_name)
     |> IO.inspect(label: "do_start_link return")
   end
@@ -367,8 +372,8 @@ defmodule ExAmi.Client do
   defp connecting_timer(cnt) when cnt < 20, do: 30_000
   defp connecting_timer(_), do: 60_000
 
-  defp validate_salutation("Asterisk Call Manager/1.1\r\n"), do: :ok
   defp validate_salutation("Asterisk Call Manager/1.0\r\n"), do: :ok
+  defp validate_salutation("Asterisk Call Manager/1.1\r\n"), do: :ok
   defp validate_salutation("Asterisk Call Manager/1.2\r\n"), do: :ok
   defp validate_salutation("Asterisk Call Manager/1.3\r\n"), do: :ok
 
@@ -379,6 +384,8 @@ defmodule ExAmi.Client do
       saluation_error(saluation)
     end
   end
+
+  defp validate_salutation("Asterisk Call Manager/7.0.1\r\n"), do: :ok
 
   defp validate_salutation(invalid_id) do
     saluation_error(invalid_id)

--- a/lib/ex_ami/supervisor.ex
+++ b/lib/ex_ami/supervisor.ex
@@ -15,7 +15,11 @@ defmodule ExAmi.Supervisor do
   end
 
   def start_child(server_name, worker_name, server_info),
-    do: DynamicSupervisor.start_child(:exami_supervisor, {ExAmi.Client, [server_name, worker_name, server_info]})
+    do:
+      DynamicSupervisor.start_child(
+        :exami_supervisor,
+        {ExAmi.Client, [server_name, worker_name, server_info]}
+      )
 
   def start_child(server_name),
     do: DynamicSupervisor.start_child(:exami_supervisor, {ExAmi.Client, [server_name]})


### PR DESCRIPTION
This adds support for Asterisk 18 by including an additional function clause for `ExAmi.Client.validate_salutation/1`.

I've also created a `.formatter.exs` file and ran `mix format` on the branch.