### PR TITLE
Allow Call Manager 9.0 for Asterisk 20

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2022 E-MetroTel
+Copyright (c) 2015-2025 E-MetroTel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ This requires that your application must be changed.
 ## Trouble Shooting
 
 * Ensure you start the ex_ami application in your mix.exs file as described above
-* Enusre you setup the ex_ami configuration with the correct credentials
+* Ensure you setup the ex_ami configuration with the correct credentials
 * Enusre you setup the credentials for the AMI connection in Asterisk
 
 ## License
 
-ex_ami is Copyright (c) 2015-2022 E-MetroTel
+ex_ami is Copyright (c) 2015-2025 E-MetroTel
 
 The source code is released under the MIT License.
 

--- a/lib/ex_ami/client.ex
+++ b/lib/ex_ami/client.ex
@@ -241,7 +241,7 @@ defmodule ExAmi.Client do
           end
 
         other ->
-          Logger.warn(
+          Logger.warning(
             "Could not find action for response: #{inspect(response)}. Received #{inspect(other)}"
           )
 
@@ -357,6 +357,10 @@ defmodule ExAmi.Client do
   defp connecting_timer(cnt) when cnt < 20, do: 30_000
   defp connecting_timer(_), do: 60_000
 
+  defp validate_salutation("Asterisk Call Manager/9.0." <> patch = salutation) do
+    check_version(patch, salutation)
+  end
+
   defp validate_salutation("Asterisk Call Manager/7.0." <> patch = salutation) do
     check_version(patch, salutation)
   end
@@ -395,7 +399,7 @@ defmodule ExAmi.Client do
   end
 
   defp do_receive_action(action, action_id, old_action, callback, state) do
-    Logger.warn(
+    Logger.warning(
       "duplicate action ID #{action_id}\nold action: #{inspect(old_action)}\nnew_action: #{inspect(action)}"
     )
 

--- a/lib/ex_ami/logger.ex
+++ b/lib/ex_ami/logger.ex
@@ -26,12 +26,12 @@ defmodule ExAmi.Logger do
     end
   end
 
-  defmacro warn(message, metadata \\ []) do
+  defmacro warning(message, metadata \\ []) do
     quote do
       message = unquote(message)
       metadata = unquote(metadata)
 
-      Logger.warn(message, metadata)
+      Logger.warning(message, metadata)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExAmi.Mixfile do
   def project do
     [
       app: :ex_ami,
-      version: "1.1.0",
+      version: "2.0.0",
       elixir: "~> 1.12",
       package: package(),
       name: "ExAmi",
@@ -37,7 +37,7 @@ defmodule ExAmi.Mixfile do
 
   defp package do
     [
-      maintainers: ["Stephen Pallen"],
+      maintainers: ["Ian Sinclair", "Stephen Pallen"],
       licenses: ["MIT"],
       links: %{"Github" => "https://github.com/smpallen99/ex_ami"},
       files: ~w(lib README.md mix.exs LICENSE)

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -45,16 +45,19 @@ defmodule ExAmi.ClientTest do
 
     action_id_alt = action_id <> "_alt"
 
-    {:next_state, :receiving, state} = Client.receiving(:cast, {:action, action, callback}, state)
+    capture_log(fn ->
+      {:next_state, :receiving, state} =
+        Client.receiving(:cast, {:action, action, callback}, state)
 
-    action2 = Message.put(action, "ActionID", action_id_alt)
+      action2 = Message.put(action, "ActionID", action_id_alt)
 
-    assert state.actions == %{
-             action_id => {action, :none, [], callback},
-             action_id_alt => {action2, :none, [], callback}
-           }
+      assert state.actions == %{
+               action_id => {action, :none, [], callback},
+               action_id_alt => {action2, :none, [], callback}
+             }
 
-    assert_receive {:connection, ^action2}
+      assert_receive {:connection, ^action2}
+    end) =~ "duplicate action ID"
   end
 
   test "handle QueueStatusResponse", %{state: state} do


### PR DESCRIPTION
This submission simply allows the connection with Call Manager 9.0 to occur. Further testing will be required to determine if any changes are needed to support the new release.